### PR TITLE
Upgrade gatekeeper package

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -301,6 +301,7 @@ images:
       - v3.2.2
       - v3.4.0
       - v3.5.1
+      - v3.5.2
     destinations:
       - reg.sighup.io/sighupio/fury/openpolicyagent/gatekeeper
       - registry.sighup.io/fury/openpolicyagent/gatekeeper


### PR DESCRIPTION
There is a bugfix in this release that is necessary to keep the backward compatibility of `constraints`. The issue fixed in [this upstream PR.](https://github.com/open-policy-agent/frameworks/pull/130)