### PR TITLE
Sync kubectl controls the Kubernetes cluster manager.

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -836,6 +836,16 @@ images:
       - reg.sighup.io/sighupio/fury/istio/sidecar_injector
       - registry.sighup.io/fury/istio/sidecar_injector
 
+  - name: Kubectl
+    source: quay.io/sighup/kubectl
+    tag:
+      - v1.18.19
+      - v1.19.11
+      - v1.20.7
+      - v1.21.1
+      - v1.22.0
+    destinations:
+      - registry.sighup.io/fury/kubectl
 
   - name: Alpine 3
     source: docker.io/library/alpine:3


### PR DESCRIPTION
This PR syncs the `kubectl` image also with out Harbor registry. This is mostly to stay consistent across the KFD modules to use the harbor images instead of pullong from quay.