### PR TITLE
[DOCS] Change README for the public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 style="font-size: 25px">
+<h1>
     <img src="https://github.com/sighupio/fury-distribution/blob/master/docs/assets/fury-epta-white.png?raw=true" align="left" width="90" style="margin-right: 15px"/>
     Kubernetes Fury Distribution - Container Image Sync
 </h1>


### PR DESCRIPTION
Hi team, I wrote un updated README.md ready for the public release of the repo.

I'm also thinking to rename this repository from `container-image-sync` to `fury-distribution-container-image-sync`

Additionally, we should think on renaming the repository https://github.com/sighupio/fury-images on something different from `fury`, because it is consultancy related