### PR TITLE
Kuma images 1.4.1

### DIFF
--- a/modules/service-mesh/images.yml
+++ b/modules/service-mesh/images.yml
@@ -162,3 +162,31 @@ images:
       - "1.3.3"
     destinations:
       - registry.sighup.io/fury/kong/kuma-init
+
+  - name: Kuma Control Plane
+    source: docker.io/kumahq/kuma-cp
+    tag:
+      - "1.4.1"
+    destinations:
+      - registry.sighup.io/fury/kumahq/kuma-cp
+
+  - name: Kuma Data Plane
+    source: docker.io/kumahq/kuma-dp
+    tag:
+      - "1.4.1"
+    destinations:
+      - registry.sighup.io/fury/kumahq/kuma-dp
+
+  - name: Kuma Prometheus Service Discovery
+    source: docker.io/kumahq/kuma-prometheus-sd
+    tag:
+      - "1.4.1"
+    destinations:
+      - registry.sighup.io/fury/kumahq/kuma-prometheus-sd
+
+  - name: Kuma Init
+    source: docker.io/kumahq/kuma-init
+    tag:
+      - "1.4.1"
+    destinations:
+      - registry.sighup.io/fury/kumahq/kuma-init


### PR DESCRIPTION
As per PR title. This is required, since Kuma uses different images from Kong Mesh.