### PR TITLE
feat(monitoring): add prometheus-adapter v0.5.0

### DIFF
--- a/modules/monitoring/images.yml
+++ b/modules/monitoring/images.yml
@@ -6,6 +6,12 @@ images:
     destinations:
       - registry.sighup.io/fury/prometheus-adapter/prometheus-adapter
 
+  - name: Prometheus adapter direcxman (old version) [Fury Monitoring Module]
+    source: quay.io/coreos/k8s-prometheus-adapter-amd64
+    tag:
+      - "v0.5.0"
+    destinations:
+      - registry.sighup.io/fury/prometheus-adapter/prometheus-adapter
 
   - name: Alertmanager [Fury Monitoring Module]
     source: quay.io/prometheus/alertmanager


### PR DESCRIPTION
Import prometheus-adapter v0.5.0

The image is downloaded from quay.io to avoid PullRateLimits from DockerHub and because versions previous `v0.8.4` are not available from k8s.gcr.io registry.

References:
- https://github.com/kubernetes-sigs/prometheus-adapter/releases/tag/v0.5.0
- https://github.com/kubernetes-sigs/prometheus-adapter#official-images