### PR TITLE
feat: added 9.5.5 grafana version

### DIFF
--- a/modules/monitoring/images.yml
+++ b/modules/monitoring/images.yml
@@ -72,6 +72,7 @@ images:
       - "8.5.5"
       - "9.3.2"
       - "9.3.6"
+      - "9.5.5"
     destinations:
       - registry.sighup.io/fury/grafana/grafana
 


### PR DESCRIPTION
Add a new version of grafana duo the [CVE-2023-3128](https://github.com/prometheus-operator/kube-prometheus/issues/2147)