### PR TITLE
feat: update skopeo stable to v1.13 (v1.9 has expired on quay)

### DIFF
--- a/.github/workflows/dry.yml
+++ b/.github/workflows/dry.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Iterate
         run: |
           yq --version
-          docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+          docker run --rm quay.io/skopeo/stable:v1.13 --version
           ./sync.sh --dry-run

--- a/.github/workflows/sync-auth.yml
+++ b/.github/workflows/sync-auth.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Iterate
         run: |
           yq --version
-          docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+          docker run --rm quay.io/skopeo/stable:v1.13 --version
           ./single_sync.sh modules/auth/images.yml false

--- a/.github/workflows/sync-aws.yml
+++ b/.github/workflows/sync-aws.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/aws/images.yml false

--- a/.github/workflows/sync-dr.yml
+++ b/.github/workflows/sync-dr.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/dr/images.yml false

--- a/.github/workflows/sync-extra.yml
+++ b/.github/workflows/sync-extra.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/extra/images.yml false

--- a/.github/workflows/sync-ingress.yml
+++ b/.github/workflows/sync-ingress.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/ingress/images.yml false

--- a/.github/workflows/sync-kafka.yml
+++ b/.github/workflows/sync-kafka.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Iterate
         run: |
           yq --version
-          docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+          docker run --rm quay.io/skopeo/stable:v1.13 --version
           ./single_sync.sh modules/kafka/images.yml false

--- a/.github/workflows/sync-keycloak.yml
+++ b/.github/workflows/sync-keycloak.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/keycloak/images.yml false

--- a/.github/workflows/sync-kong.yml
+++ b/.github/workflows/sync-kong.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/kong/images.yml false

--- a/.github/workflows/sync-logging.yml
+++ b/.github/workflows/sync-logging.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/logging/images.yml false

--- a/.github/workflows/sync-monitoring.yml
+++ b/.github/workflows/sync-monitoring.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/monitoring/images.yml false

--- a/.github/workflows/sync-networking.yml
+++ b/.github/workflows/sync-networking.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/networking/images.yml false

--- a/.github/workflows/sync-on-premises.yml
+++ b/.github/workflows/sync-on-premises.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/on-premises/images.yml false

--- a/.github/workflows/sync-opa.yml
+++ b/.github/workflows/sync-opa.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/opa/images.yml false

--- a/.github/workflows/sync-postgresql.yml
+++ b/.github/workflows/sync-postgresql.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/postgresql/images.yml false

--- a/.github/workflows/sync-redis.yml
+++ b/.github/workflows/sync-redis.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/redis/images.yml false

--- a/.github/workflows/sync-registry.yml
+++ b/.github/workflows/sync-registry.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/registry/images.yml false

--- a/.github/workflows/sync-service-mesh.yml
+++ b/.github/workflows/sync-service-mesh.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Iterate
       run: |
         yq --version
-        docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+        docker run --rm quay.io/skopeo/stable:v1.13 --version
         ./single_sync.sh modules/service-mesh/images.yml false

--- a/.github/workflows/sync-storage.yml
+++ b/.github/workflows/sync-storage.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Iterate
         run: |
           yq --version
-          docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+          docker run --rm quay.io/skopeo/stable:v1.13 --version
           ./single_sync.sh modules/storage/images.yml false

--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Iterate
         run: |
           yq --version
-          docker run --rm quay.io/skopeo/stable:v1.9.2 --version
+          docker run --rm quay.io/skopeo/stable:v1.13 --version
           ./single_sync.sh modules/vault/images.yml false


### PR DESCRIPTION
as per title