### PR TITLE
feat(networking): add calico and tigera images for 1.27

### DIFF
--- a/modules/networking/images.yml
+++ b/modules/networking/images.yml
@@ -5,6 +5,7 @@ images:
       - "v1.28.1"
       - "v1.29.0"
       - "v1.30.4"
+      - "v1.30.7"
     destinations:
       - registry.sighup.io/fury/tigera/operator
 
@@ -24,6 +25,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/kube-controllers
 
@@ -43,6 +45,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/cni
 
@@ -81,6 +84,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/node
 
@@ -90,6 +94,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/apiserver
 
@@ -99,6 +104,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/typha
 
@@ -108,6 +114,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/csi
 
@@ -117,6 +124,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/node-driver-registrar
 


### PR DESCRIPTION
Includes calico and calico operator images for KFD 1.27.
- Tigera operator v1.30.7
- Calico images v3.26.3