### PR TITLE
fix: missing calico image for 3.26.3

### DIFF
--- a/modules/networking/images.yml
+++ b/modules/networking/images.yml
@@ -67,6 +67,7 @@ images:
       - "v3.24.1"
       - "v3.25.0"
       - "v3.26.1"
+      - "v3.26.3"
     destinations:
       - registry.sighup.io/fury/calico/pod2daemon-flexvol
 


### PR DESCRIPTION
as per title