### PR TITLE
Calico v3.27.0

### DIFF
--- a/modules/networking/images.yml
+++ b/modules/networking/images.yml
@@ -26,6 +26,7 @@ images:
       - "v3.25.0"
       - "v3.26.1"
       - "v3.26.3"
+      - "v3.27.0"
     destinations:
       - registry.sighup.io/fury/calico/kube-controllers
 
@@ -47,6 +48,7 @@ images:
       - "v3.25.0"
       - "v3.26.1"
       - "v3.26.3"
+      - "v3.27.0"
     destinations:
       - registry.sighup.io/fury/calico/cni
 
@@ -89,6 +91,7 @@ images:
       - "v3.25.0"
       - "v3.26.1"
       - "v3.26.3"
+      - "v3.27.0"
     destinations:
       - registry.sighup.io/fury/calico/node
 


### PR DESCRIPTION
Import the images for upgrading calico to version v3.27.0.