### PR TITLE
feat(cert-manager): version bump 14.2 add ACME solver

### DIFF
--- a/modules/ingress/images.yml
+++ b/modules/ingress/images.yml
@@ -58,6 +58,7 @@ images:
       - "v1.11.0"
       - "v1.11.1"
       - "v1.13.1"
+      - "v1.14.2"
     destinations:
       - registry.sighup.io/fury/jetstack/cert-manager-cainjector
 
@@ -76,6 +77,7 @@ images:
       - "v1.11.0"
       - "v1.11.1"
       - "v1.13.1"
+      - "v1.14.2"
     destinations:
       - registry.sighup.io/fury/jetstack/cert-manager-controller
 
@@ -94,8 +96,16 @@ images:
       - "v1.11.0"
       - "v1.11.1"
       - "v1.13.1"
+      - "v1.14.2"
     destinations:
       - registry.sighup.io/fury/jetstack/cert-manager-webhook
+
+  - name: ACME Solver - Cert Manager [Fury Kubernetes Ingress]
+    source: quay.io/jetstack/cert-manager-acmesolver
+    tag:
+      - "v1.14.2"
+    destinations:
+      - registry.sighup.io/fury/jetstack/cert-manager-acmesolver
 
   - name: External DNS [Fury Kubernetes Ingress]
     source: k8s.gcr.io/external-dns/external-dns


### PR DESCRIPTION
This PR updates Cert-Manager to version 14.2, introducing a new ACME Solver image:

- Upgraded Cert-Manager to v14.2.
- Added ACME Solver image
