### PR TITLE
feat(monitoring): add grafana kuma plugin

### DIFF
--- a/modules/monitoring/custom/grafana/Dockerfile
+++ b/modules/monitoring/custom/grafana/Dockerfile
@@ -29,7 +29,7 @@ USER grafana
 ENV GF_PLUGIN_RENDERING_CHROME_BIN="/usr/bin/chromium-browser"
 
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
-    grafana-cli \
+    grafana cli \
         --pluginsDir "$GF_PATHS_PLUGINS" \
         --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-linux-x64-glibc-no-chromium.zip \
         plugins install grafana-image-renderer; \
@@ -45,9 +45,13 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
         if expr match "$plugin" '.*\;.*'; then \
             pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
             pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
-            grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
+            grafana cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
         else \
-            grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
+            grafana cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
         fi \
     done \
 fi
+
+ARG GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
+
+ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=$GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS

--- a/modules/monitoring/images.yml
+++ b/modules/monitoring/images.yml
@@ -76,21 +76,6 @@ images:
       context: custom/grafana
       args:
         - name: GF_INSTALL_PLUGINS
-          value: grafana-piechart-panel
-    tag:
-      - "8.5.5"
-      - "9.3.2"
-      - "9.3.6"
-      - "9.5.5"
-    destinations:
-      - registry.sighup.io/fury/grafana/grafana
-
-  - name: Grafana + Kuma Plugin [Fury Monitoring Module]
-    source: grafana
-    build:
-      context: custom/grafana
-      args:
-        - name: GF_INSTALL_PLUGINS
           value: grafana-piechart-panel,https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.1.1/kumahq-kuma-datasource-0.1.1.zip;kumahq-kuma-datasource
         # The plugin is not signed: see https://github.com/kumahq/kuma-grafana-datasource
         - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
@@ -101,7 +86,7 @@ images:
       - "9.3.6"
       - "9.5.5"
     destinations:
-      - registry.sighup.io/fury/grafana/grafana-kuma
+      - registry.sighup.io/fury/grafana/grafana
 
   - name: kube-state-metrics [Fury Monitoring Module]
     source: quay.io/coreos/kube-state-metrics

--- a/modules/monitoring/images.yml
+++ b/modules/monitoring/images.yml
@@ -85,6 +85,24 @@ images:
     destinations:
       - registry.sighup.io/fury/grafana/grafana
 
+  - name: Grafana + Kuma Plugin [Fury Monitoring Module]
+    source: grafana
+    build:
+      context: custom/grafana
+      args:
+        - name: GF_INSTALL_PLUGINS
+          value: grafana-piechart-panel,https://github.com/kumahq/kuma-grafana-datasource/releases/download/v0.1.1/kumahq-kuma-datasource-0.1.1.zip;kumahq-kuma-datasource
+        # The plugin is not signed: see https://github.com/kumahq/kuma-grafana-datasource
+        - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
+          value: kumahq-kuma-datasource
+    tag:
+      - "8.5.5"
+      - "9.3.2"
+      - "9.3.6"
+      - "9.5.5"
+    destinations:
+      - registry.sighup.io/fury/grafana/grafana-kuma
+
   - name: kube-state-metrics [Fury Monitoring Module]
     source: quay.io/coreos/kube-state-metrics
     tag:


### PR DESCRIPTION
This change does the following:

- updates `grafana-cli` to `grafana cli` because of deprecation
- creates a new image called `grafana-kuma` based on the same Dockerfile, but it also installs the [Kuma Datasource plugin](https://github.com/kumahq/kuma-grafana-datasource)
- since this plugin is not signed, we also need to tell Grafana to allow this unsigned plugin explicitly: this is done by the variable `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS` which does not affect the original image, since it's empty at build time

Another option could be to install this plugin in our Grafana image always