### PR TITLE
feat(extra): add busybox stable

### DIFF
--- a/modules/extra/images.yml
+++ b/modules/extra/images.yml
@@ -150,6 +150,7 @@ images:
     source: docker.io/busybox
     tag:
       - "latest"
+      - "stable"
     destinations:
       - registry.sighup.io/fury/busybox
 


### PR DESCRIPTION
- add busybox `stable`, needed for https://github.com/sighupio/fury-kubernetes-auth/pull/28