### PR TITLE
feat(kafka): add required images for Strimzi operator v0.43.0

### DIFF
--- a/modules/kafka/images.yml
+++ b/modules/kafka/images.yml
@@ -4,6 +4,7 @@ images:
     tag:
       - "0.31.1"
       - "0.41.0"
+      - "0.43.0"
     destinations:
       - registry.sighup.io/fury/strimzi/operator
   - name: Strimzi Kafka Image [Fury Kubernetes Kafka]
@@ -19,6 +20,9 @@ images:
       - "0.41.0-kafka-3.6.1"
       - "0.41.0-kafka-3.6.2"
       - "0.41.0-kafka-3.7.0"
+      - "0.43.0-kafka-3.7.0"
+      - "0.43.0-kafka-3.7.1"
+      - "0.43.0-kafka-3.8.0"
     destinations:
       - registry.sighup.io/fury/strimzi/kafka
   - name: Strimzi Kafka Bridge [Fury Kubernetes Kafka]
@@ -26,6 +30,7 @@ images:
     tag:
       - "0.22.1"
       - "0.28.0"
+      - "0.30.0"
     destinations:
       - registry.sighup.io/fury/strimzi/kafka-bridge
   - name: Strimzi JXMtrans [Fury Kubernetes Kafka]
@@ -39,6 +44,7 @@ images:
     tag:
       - "0.31.1"
       - "0.41.0"
+      - "0.43.0"
     destinations:
       - registry.sighup.io/fury/strimzi/kaniko-executor
   - name: Strimzi Maven builder [Fury Kubernetes Kafka]
@@ -46,5 +52,6 @@ images:
     tag:
       - "0.31.1"
       - "0.41.0"
+      - "0.43.0"
     destinations:
       - registry.sighup.io/fury/strimzi/maven-builder


### PR DESCRIPTION
## Required images from [Strimzi Release page](https://github.com/strimzi/strimzi-kafka-operator/releases) added:
* quay.io/strimzi/maven-builder:0.43.0 :white_check_mark:
* quay.io/strimzi/kaniko-executor:0.43.0 :white_check_mark:
* quay.io/strimzi/kafka-bridge:0.30.0 :white_check_mark:
* quay.io/strimzi/kafka:0.43.0-kafka-3.7.0 :white_check_mark:
* quay.io/strimzi/kafka:0.43.0-kafka-3.7.1 :white_check_mark:
* quay.io/strimzi/kafka:0.43.0-kafka-3.8.0 :white_check_mark:
* quay.io/strimzi/operator:0.43.0 :white_check_mark:
