### PR TITLE
feat(modules,storage): add nfs-subdir-external-provisioner image

### DIFF
--- a/modules/storage/images.yml
+++ b/modules/storage/images.yml
@@ -69,3 +69,9 @@ images:
     destinations:
       - registry.sighup.io/fury/rook/ceph
 
+  - name: NFS subdir external provisioner [Fury Storage Module]
+    source: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner
+    tag:
+      - "v4.0.2"
+    destinations:
+      - registry.sighup.io/fury/sig-storage/nfs-subdir-external-provisioner


### PR DESCRIPTION
Added `registry.sighup.io/fury/sig-storage/nfs-subdir-external-provisioner`