### PR TITLE
feat(logging): add loki v2.9.10

### DIFF
--- a/modules/logging/images.yml
+++ b/modules/logging/images.yml
@@ -6,6 +6,7 @@ images:
       - "2.7.3"
       - "2.8.0"
       - "2.9.2"
+      - "2.9.10"
       - "3.2.0"
     destinations:
       - registry.sighup.io/fury/grafana/loki


### PR DESCRIPTION
This PR adds loki v2.9.10 image for loki-distributed upgrade.