### PR TITLE
feat(velero): add snapshot-controller for velero 1.15 csi snapshots

### DIFF
--- a/modules/dr/images.yml
+++ b/modules/dr/images.yml
@@ -136,3 +136,10 @@ images:
   - "latest"
   destinations:
   - registry.sighup.io/fury/minio/mc
+
+- name: Snapshot Controller [Fury Kubernetes DR]
+  source: registry.k8s.io/sig-storage/snapshot-controller
+  tag:
+  - "v8.0.1"
+  destinations:
+  - registry.sighup.io/fury/sig-storage/snapshot-controller


### PR DESCRIPTION
Add *snapshot-controller* `v8.0.1` in DR module.