### PR TITLE
feat(images): add v2.13.0 tag for kube-state-metrics

### DIFF
--- a/modules/monitoring/images.yml
+++ b/modules/monitoring/images.yml
@@ -119,6 +119,7 @@ images:
     multi-arch: true
     tag:
       - "v2.9.2"
+      - "v2.13.0"
     destinations:
       - registry.sighup.io/fury/kube-state-metrics/kube-state-metrics
 


### PR DESCRIPTION
add v2.13.0 tag for kube-state-metrics