### PR TITLE
Add images needed for AWS installer upgrades

### DIFF
--- a/modules/aws/images.yml
+++ b/modules/aws/images.yml
@@ -6,6 +6,7 @@ images:
       - "v1.17.1"
       - "v1.19.0"
       - "v1.20.0"
+      - "v1.22.1"
     destinations:
       - registry.sighup.io/fury/aws-ec2/aws-node-termination-handler
 
@@ -22,6 +23,8 @@ images:
       - "v1.27.2"
       - "v1.28.2"
       - "v1.29.0"
+      - "v1.30.2"
+      - "v1.31.0"
 
     destinations:
       - registry.sighup.io/fury/autoscaling/cluster-autoscaler
@@ -33,6 +36,7 @@ images:
       - "v2.4.7"
       - "v2.6.0"
       - "v2.7.0"
+      - "v2.10.0"
     destinations:
       - registry.sighup.io/fury/amazon/aws-alb-ingress-controller
 
@@ -101,6 +105,7 @@ images:
       - "v6.2.1"
       - "v6.3.0"
       - "v6.3.1"
+      - "v8.0.1"
     destinations:
       - registry.sighup.io/fury/sig-storage/snapshot-controller
 


### PR DESCRIPTION
- Added aws-node-termination-handler v1.22.1 image
- Added cluster-autoscaler images for v1.30 and v1.31
- Added aws-load-balancer-controller v2.10.0 image
- Added snapshot-controller v8.0.1 image