### PR TITLE
feat: add redis 7.4.2-alpine3.21

### DIFF
--- a/modules/redis/images.yml
+++ b/modules/redis/images.yml
@@ -21,6 +21,7 @@ images:
       - "alpine3.12"
       - "6.2.5-alpine3.14"
       - "7.2.3-alpine3.19"
+      - "7.4.2-alpine3.21"
     destinations:
       - registry.sighup.io/fury/redis
 


### PR DESCRIPTION
This PR adds the redis 7.4.2-alpine3.21 image for the fury registry.

# Checklist for Testing 🧪

- [x] The image exists and runs without issues

# Details ⚙️ 
- Added version 7.4.2 of Redis using Alpine 3.21

# Breaking Changes 💔 
- No breaking changes