### PR TITLE
feat: update calico to 3.29.2 and tigera operator to 1.36.5

### DIFF
--- a/modules/networking/images.yml
+++ b/modules/networking/images.yml
@@ -9,6 +9,7 @@ images:
       - "v1.32.3"
       - "v1.32.7"
       - "v1.36.0"
+      - "v1.36.5"
     destinations:
       - registry.sighup.io/fury/tigera/operator
 
@@ -32,6 +33,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/kube-controllers
 
@@ -56,6 +58,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/cni
 
@@ -80,6 +83,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/pod2daemon-flexvol
 
@@ -104,6 +108,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/node
 
@@ -117,6 +122,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/apiserver
 
@@ -130,6 +136,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/typha
 
@@ -144,6 +151,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/csi
 
@@ -158,6 +166,7 @@ images:
       - "v3.27.0"
       - "v3.27.3"
       - "v3.29.0"
+      - "v3.29.2"
     destinations:
       - registry.sighup.io/fury/calico/node-driver-registrar
 


### PR DESCRIPTION
As per title, this PR updates calico and tigera operator to 3.29.2 and 1.36.5 respectively