### PR TITLE
Add multi-node support and failure resiliency to etcd-backupper

### DIFF
--- a/modules/dr/custom/etcd-backupper/Dockerfile
+++ b/modules/dr/custom/etcd-backupper/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:${ALPINE}
 ARG ETCD_VER=v3.5.19
 ARG TARGETARCH
 
-RUN apk add curl yq jq
+RUN apk add curl yq
 
 RUN mkdir /tmp/etcd-download-test
 

--- a/modules/dr/custom/etcd-backupper/Dockerfile
+++ b/modules/dr/custom/etcd-backupper/Dockerfile
@@ -1,10 +1,10 @@
 ARG ALPINE=3.21
-FROM --platform=$TARGETPLATFORM alpine:${ALPINE}
+FROM alpine:${ALPINE}
 
 ARG ETCD_VER=v3.5.19
 ARG TARGETARCH
 
-RUN apk add curl yq
+RUN apk add curl yq jq
 
 RUN mkdir /tmp/etcd-download-test
 

--- a/modules/dr/custom/etcd-backupper/README.md
+++ b/modules/dr/custom/etcd-backupper/README.md
@@ -1,12 +1,13 @@
 # etcd-backupper
-A simple Alpine-based image which contains `etcdctl`, `yq`
-and `jq` to assist the `etcd-backup-*` features.
+A simple Alpine-based image which contains `etcdctl` and `yq`
+to assist the `etcd-backup-*` features.
 
 ## Endpoint detection
 There is some logic to try to automatically detect which endpoints
 are the `etcd` servers listening on, but in order to make this work
 you have to mount the `ClusterConfiguration` config-map as a volume
-under `/k8s/config.yaml`. If this isn't mounted, we rely on what's provided by outside.
+under `/k8s/config.yaml`. If this isn't mounted, we rely on 
+what's provided by outside.
 
 ## Health detection
 Since the `etcdctl snapshot save` command needs one and

--- a/modules/dr/custom/etcd-backupper/README.md
+++ b/modules/dr/custom/etcd-backupper/README.md
@@ -1,10 +1,16 @@
 # etcd-backupper
-A simple Alpine-based image which contains `etcdctl` and `yq` to
-assist the `etcd-backup-*` features.
+A simple Alpine-based image which contains `etcdctl`, `yq`
+and `jq` to assist the `etcd-backup-*` features.
 
 ## Endpoint detection
 There is some logic to try to automatically detect which endpoints
 are the `etcd` servers listening on, but in order to make this work
 you have to mount the `ClusterConfiguration` config-map as a volume
-under `/k8s/config.yaml`. If this isn't mounted, there's a fallback
-endpoint (`https://127.0.0.1:2379`).
+under `/k8s/config.yaml`. If this isn't mounted, we rely on what's provided by outside.
+
+## Health detection
+Since the `etcdctl snapshot save` command needs one and
+only one endpoint to perform the snapshot, we need to
+choose which one. This is chosen by asking the whole
+etcd cluster which node is healthy. Then we snapshot that
+node.

--- a/modules/dr/custom/etcd-backupper/init.sh
+++ b/modules/dr/custom/etcd-backupper/init.sh
@@ -18,7 +18,7 @@ export ETCDCTL_CERT="$ETCDCTL_CERT"
 export ETCDCTL_KEY="$ETCDCTL_KEY"
 
 # Select the first healthy endpoint
-ENDPOINT=$(etcdctl endpoint health -w json | jq '[.[] | select(.health == true)][0].endpoint' -r)
+ENDPOINT=$(etcdctl endpoint health -w json | yq '[.[] | select(.health == true)][0].endpoint' -r)
 
 # Use only the healthy endpoint for backup
 export ETCDCTL_ENDPOINTS=$ENDPOINT

--- a/modules/dr/custom/etcd-backupper/init.sh
+++ b/modules/dr/custom/etcd-backupper/init.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env sh
 
+# Configuration file path
 CONFIG_FILE="/k8s/config.yaml"
-ETCDCTL_ENDPOINTS="https://127.0.0.1:2379"
 
+# Load ETCD endpoints from config file if it exists
 if [ -f "$CONFIG_FILE" ]; then
     ENDPOINTS=$(yq eval '.etcd.external.endpoints | join(",")' "$CONFIG_FILE")
-    
+
     [ -n "$ENDPOINTS" ] && ETCDCTL_ENDPOINTS="$ENDPOINTS"
 fi
 
-ETCDCTL_API=3 \
-ETCDCTL_ENDPOINTS="$ETCDCTL_ENDPOINTS" \
-ETCDCTL_CACERT="$ETCDCTL_CACERT" \
-ETCDCTL_CERT="$ETCDCTL_CERT" \
-ETCDCTL_KEY="$ETCDCTL_KEY" \
+# Set ETCD client environment variables
+export ETCDCTL_API=3
+export ETCDCTL_ENDPOINTS="$ETCDCTL_ENDPOINTS"
+export ETCDCTL_CACERT="$ETCDCTL_CACERT"
+export ETCDCTL_CERT="$ETCDCTL_CERT"
+export ETCDCTL_KEY="$ETCDCTL_KEY"
+
+# Select the first healthy endpoint
+ENDPOINT=$(etcdctl endpoint health -w json | jq '[.[] | select(.health == true)][0].endpoint' -r)
+
+# Use only the healthy endpoint for backup
+export ETCDCTL_ENDPOINTS=$ENDPOINT
+
+# Create timestamped ETCD snapshot backup
 etcdctl snapshot save /backup/fury-etcd-snapshot-$(date +'%Y%m%d%H%M').etcdb


### PR DESCRIPTION
Since the `etcdctl snapshot save` command needs one and only one endpoint to perform the snapshot, we need to choose which one. This is chosen by asking the whole etcd cluster which node is healthy, then we snapshot that node.
