### PR TITLE
feat(logging): add loki 3.4.2 and nginx 1.27.3-alpine

### DIFF
--- a/modules/logging/images.yml
+++ b/modules/logging/images.yml
@@ -8,6 +8,7 @@ images:
       - "2.9.2"
       - "2.9.10"
       - "3.2.0"
+      - "3.4.2"
     destinations:
       - registry.sighup.io/fury/grafana/loki
 
@@ -243,6 +244,7 @@ images:
       - "1.20.2-alpine"
       - "1.25-alpine"
       - "1.27-alpine"
+      - "1.27.3-alpine"
     destinations:
       - registry.sighup.io/fury/nginxinc/nginx-unprivileged
   


### PR DESCRIPTION
This PR adds the loki 3.4.2 and nginx 1.27.3-alpine image for the fury registry.

# Checklist for Testing 🧪

- [x] The images exists and runs without issues

# Details ⚙️ 
- Added version 3.4.2 of Loki
- Added version 1.27.3 of nginx using Alpine

# Breaking Changes 💔 
- No breaking changes