### PR TITLE
Update registry images to version 2.9.5

### DIFF
--- a/modules/registry/images.yml
+++ b/modules/registry/images.yml
@@ -50,6 +50,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/harbor-core
 
@@ -64,6 +65,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/harbor-jobservice
 
@@ -106,6 +108,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/harbor-portal
 
@@ -120,6 +123,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/registry-photon
 
@@ -134,6 +138,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/harbor-registryctl
 
@@ -148,6 +153,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/redis-photon
 
@@ -162,6 +168,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/harbor-db
 
@@ -175,6 +182,7 @@ images:
       - "v2.3.2"
       - "v2.4.2"
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/trivy-adapter-photon
 
@@ -182,6 +190,7 @@ images:
     source: docker.io/goharbor/harbor-exporter
     tag:
       - "v2.7.0"
+      - "v2.9.5"
     destinations:
       - registry.sighup.io/fury/goharbor/harbor-exporter
 


### PR DESCRIPTION
This PR adds support for images needed for Harbor Registry version 2.9.5.