### PR TITLE
feat(extra): add kubectl

### DIFF
--- a/modules/extra/images.yml
+++ b/modules/extra/images.yml
@@ -101,17 +101,20 @@ images:
   #    destinations:
   #      - registry.sighup.io/workshop/nginx
 
-  #- name: Kubectl
-  #  source: quay.io/sighup/kubectl
-  #  tag:
-  #    - "v1.18.19"
-  #    - "v1.19.11"
-  #    - "v1.20.7"
-  #    - "v1.21.1"
-  #    - "v1.22.0"
-  #    - "v1.23.0"
-  #  destinations:
-  #    - registry.sighup.io/fury/kubectl
+  - name: Kubectl
+    source: registry.k8s.io/kubectl
+    tag:
+      # - "v1.18.19"
+      # - "v1.19.11"
+      # - "v1.20.7"
+      # - "v1.21.1"
+      # - "v1.22.0"
+      # - "v1.23.0"
+      - v1.31.12
+      - v1.32.8
+      - v1.33.4
+    destinations:
+      - registry.sighup.io/fury/kubectl
 
   - name: nginx Latest
     source: docker.io/library/nginx


### PR DESCRIPTION
Add back the Kubectl image sync, using the official image from registry.k8s.io.

The selected versions follow the on-prem installer's Kubernetes versions