### PR TITLE
Headlamp container image

### DIFF
--- a/modules/ui/images.yml
+++ b/modules/ui/images.yml
@@ -1,0 +1,8 @@
+images:
+  - name: Headlamp [SIGHUP Distribution UI]
+    source: ghcr.io/headlamp-k8s/headlamp
+    tag:
+      - "v0.41.0"
+      - "v0.40.1"
+    destinations:
+      - registry.sighup.io/fury/headlamp


### PR DESCRIPTION
This PR aims to add the Headlamp container image to be synced from the related container registry.

The `ui` module has been created.