### PR TITLE
feat/fix: add pre build commands and move chainguard nginx ingress controller on it's own folder/module

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,6 +103,9 @@ images:
       git_source:                   # Optional, build context from external repo
         repo: "https://github.com/org/repo.git"
         ref: "v1.2.3"               # tag or branch (not a raw commit SHA)
+      pre_build_commands:           # Optional, shell commands run in
+        - "make build ARCH=amd64"   # dirname(context) before the docker
+        - "make build ARCH=arm64"   # build (e.g. cross-compile, codegen)
       args:
         - name: "BUILD_ARG"
           value: "value"
@@ -116,7 +119,7 @@ images:
 When `build.git_source` is present, the script shallow-clones the repo at
 the given ref into a tempdir and uses `<tempdir>/<context>` as the docker
 build context. See the [README](README.md#external-git-sources) and the
-[Chainguard forks catalog](docs/CHAINGUARD_FORKS.md) for details.
+[Chainguard forks catalog](modules/chainguard-forks/README.md) for details.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,44 @@ How it works at sync time:
 - When `git_source` is present, the local path
   `dirname(images.yml)/<context>` is ignored.
 
+### Pre-build commands
+
+Some forks ship Dockerfiles that are NOT self-contained — they require code
+generation, Go cross-compilation, or other prep before `docker build` can run
+(for example the Chainguard `ingress-nginx` fork's `rootfs/Dockerfile` does
+`COPY bin/${TARGETARCH}/...` expecting Go binaries that the project's own
+`make build ARCH=<arch>` target produces).
+
+To handle this, add `build.pre_build_commands`: a list of shell command strings
+executed sequentially with `bash -c`, in `dirname(<context>)` (the parent of
+the docker build context — i.e. the clone root for `git_source` builds), AFTER
+the clone and BEFORE the `docker buildx build`. If any command fails the entry
+aborts.
+
+```yaml
+  - name: Example with pre-build
+    source: example-local-name
+    multi-arch: true
+    build:
+      git_source:
+        repo: https://github.com/some-org/some-repo.git
+        ref: v1.2.3
+      pre_build_commands:
+        - "make build ARCH=amd64 TAG=v1.2.3"
+        - "make build ARCH=arm64 TAG=v1.2.3"
+      context: rootfs
+      args:
+        - name: VERSION
+          value: "v1.2.3"
+    tag:
+      - "v1.2.3-custom"
+    destinations:
+      - registry.sighup.io/fury/example/image
+```
+
 For the current catalog of Chainguard-maintained forks adopted with this
 mechanism (image mappings to the SIGHUP registry and bump procedures),
-see [`docs/CHAINGUARD_FORKS.md`](docs/CHAINGUARD_FORKS.md).
+see [`modules/chainguard-forks/README.md`](modules/chainguard-forks/README.md).
 
 ## <a name="automated-sync-execution">Automated sync execution</a>
 

--- a/modules/_test/images.yml
+++ b/modules/_test/images.yml
@@ -42,9 +42,10 @@ images:
     destinations:
       - registry.sighup.io/fury/testing/build-test
 
-  # Exercises build.git_source: the script must clone the external repo at the
-  # given ref into a tempdir and use <tempdir>/<context> as the docker build
-  # context. The tempdir must be removed at the end (success or failure).
+  # Exercises build.git_source AND build.pre_build_commands. The script must
+  # clone the external repo at the given ref into a tempdir, run the pre-build
+  # commands sequentially in dirname(context), and then use <tempdir>/<context>
+  # as the docker build context. The tempdir must be removed at the end.
   - name: "[TEST] Build-based git_source sync"
     source: test-build-gitsource
     multi-arch: false
@@ -52,6 +53,10 @@ images:
       git_source:
         repo: https://github.com/docker-library/hello-world.git
         ref: master
+      # Benign side-effect-free command, only used to verify the
+      # pre_build_commands code path is exercised in the test suite.
+      pre_build_commands:
+        - "ls -la"
       context: amd64/hello-world
       args:
         - name: TEST_ARG

--- a/modules/chainguard-forks/README.md
+++ b/modules/chainguard-forks/README.md
@@ -6,8 +6,8 @@ upstream provenance, the reason we adopted the fork, the resulting registry
 mapping, the build cascade (when applicable), and the bump procedure.
 
 For the concrete versions currently in use, look at the corresponding
-`images.yml` — this document deliberately does not pin versions, so it
-does not go stale every time a tag is bumped.
+[`images.yml`](images.yml) — this document deliberately does not pin
+versions, so it does not go stale every time a tag is bumped.
 
 When adopting a new fork, append a section here using the same shape.
 
@@ -22,7 +22,7 @@ When adopting a new fork, append a section here using the same shape.
   the ingress-nginx modules compiled in: Lua, OpenTelemetry, ModSecurity,
   HTTP/3) and the Go controller. To benefit from those patches we have to
   build BOTH layers from the fork.
-- **Sync config**: [`modules/ingress/images.yml`](../modules/ingress/images.yml)
+- **Sync config**: [`images.yml`](images.yml)
 
 ### Images and registry mapping
 
@@ -45,17 +45,30 @@ ref is enough to drive both builds.
 The controller image's `BASE_IMAGE` build-arg points to the destination tag
 of the just-pushed nginx base image. For the cascade to resolve correctly
 the nginx base entry MUST appear before the controller entry in
-`modules/ingress/images.yml`. The sync script processes entries in order,
+[`images.yml`](images.yml). The sync script processes entries in order,
 so the order in the file determines the build order.
+
+The controller entry additionally requires a pre-build step: the fork's
+`rootfs/Dockerfile` is not self-contained and expects pre-cross-compiled Go
+binaries at `rootfs/bin/<arch>/{nginx-ingress-controller,dbg,wait-shutdown}`.
+Those are produced by the fork's own `make build ARCH=<arch>` target (which
+wraps `go build` inside a `golang:VERSION-alpine3.23` container via
+`build/run-in-docker.sh`). This is configured via `build.pre_build_commands`
+on the controller entry, with one `make build` invocation per target
+architecture. Pass `TAG=<controller-version>` explicitly to embed the
+correct release string in the Go binary (the fork's root `TAG` file is
+inconsistent with its git tags).
 
 ### Bump procedure
 
 1. Look up the latest `controller-v*` tag in the fork and read
    `images/nginx/TAG` at that tag to get the matching nginx version.
-2. Update [`modules/ingress/images.yml`](../modules/ingress/images.yml):
+2. Update [`images.yml`](images.yml):
    - Both entries: `build.git_source.ref` → the new fork tag.
    - nginx entry: `tag` value → `<NEW_NGINX_VERSION>-chainguard`.
    - controller entry:
+     - `build.pre_build_commands` → both lines updated to
+       `make build ARCH=<arch> TAG=<NEW_CONTROLLER_VERSION>`.
      - `build.args[name=BASE_IMAGE].value` → must match the new nginx
        destination tag exactly (this is the cross-reference that the
        cascade depends on).

--- a/modules/chainguard-forks/images.yml
+++ b/modules/chainguard-forks/images.yml
@@ -1,0 +1,63 @@
+# Container image builds derived from Chainguard-maintained forks of archived
+# or otherwise unmaintained upstream projects. Distinct from `modules/ingress/`
+# (and similar domain modules) which mirror upstream images verbatim: the
+# entries here BUILD images from source on every sync, so the lifecycle and
+# cadence are different.
+#
+# See README.md (sibling) for the catalog (which forks, why we adopted them,
+# registry mapping, bump procedure).
+#
+# ORDER MATTERS within the file: where one entry's BASE_IMAGE references
+# another entry's destination tag, the producer entry must appear first.
+# The sync script processes entries sequentially.
+#
+# KNOWN LIMITATION (to fix in the future): build.git_source schema accepts a
+# single `ref`, while `tag` can be a list. As a result we can build only one
+# version of the fork per entry: supporting multiple versions today requires
+# duplicating the entry (one per ref). When we need to publish more than one
+# supported line of a fork in parallel, extend the schema so git_source,
+# tag, and BASE_IMAGE can be paired across multiple versions in one entry.
+
+images:
+  - name: nginx base image [Chainguard fork]
+    source: ingress-nginx-chainguard-nginx
+    multi-arch: true
+    build:
+      git_source:
+        repo: https://github.com/chainguard-forks/ingress-nginx.git
+        ref: controller-v1.15.5
+      context: images/nginx/rootfs
+      # No build-args needed: the inner Dockerfile uses a fixed FROM alpine:3.23.3
+    tag:
+      - "v2.2.9-chainguard"
+    destinations:
+      - registry.sighup.io/fury/ingress-nginx/nginx
+
+  - name: nginx ingress controller [Chainguard fork]
+    source: ingress-nginx-chainguard-controller
+    multi-arch: true
+    build:
+      git_source:
+        repo: https://github.com/chainguard-forks/ingress-nginx.git
+        ref: controller-v1.15.5
+      # Pre-build: rootfs/Dockerfile is NOT self-contained. The commands below
+      # cross-compile the Go binaries (controller, dbg, wait-shutdown) for
+      # both target architectures via the fork's own `make build`, which runs
+      # inside a golang:VERSION-alpine3.23 container via build/run-in-docker.sh.
+      # Output lands in <clone>/rootfs/bin/<arch>/* which the docker buildx
+      # build then COPYs into the final image.
+      # TAG=v1.15.5 is explicit because the fork's root TAG file is
+      # inconsistent with the git tag (reads v1.15.0 at controller-v1.15.5).
+      pre_build_commands:
+        - "make build ARCH=amd64 TAG=v1.15.5"
+        - "make build ARCH=arm64 TAG=v1.15.5"
+      context: rootfs
+      args:
+        - name: BASE_IMAGE
+          value: "registry.sighup.io/fury/ingress-nginx/nginx:v2.2.9-chainguard"
+        - name: VERSION
+          value: "v1.15.5"
+    tag:
+      - "v1.15.5-chainguard"
+    destinations:
+      - registry.sighup.io/fury/ingress-nginx/controller

--- a/modules/ingress/images.yml
+++ b/modules/ingress/images.yml
@@ -1,5 +1,13 @@
 images:
-  - name: nginx ingress controller [Fury Kubernetes Ingress]
+  # DEPRECATED: this mirrors the (now archived) upstream
+  # k8s.gcr.io/ingress-nginx/controller. The production-blessed image is
+  # built from the Chainguard-maintained fork — see
+  # modules/chainguard-forks/ (image:
+  # registry.sighup.io/fury/ingress-nginx/controller:<ver>-chainguard).
+  # This entry is kept for downstream consumers that still pin the
+  # non-suffixed tags; remove it once module-ingress has been bumped to
+  # the -chainguard tag and no consumer references the legacy ones.
+  - name: nginx ingress controller [DEPRECATED — Fury Kubernetes Ingress]
     source: k8s.gcr.io/ingress-nginx/controller
     multi-arch: true
     tag:
@@ -167,50 +175,3 @@ images:
       - "3.2.4"
     destinations:
       - registry.sighup.io/fury/haproxytech/kubernetes-ingress
-
-  # === Chainguard fork build cascade ===
-  # The two entries below build from the Chainguard-maintained fork
-  # (https://github.com/chainguard-forks/ingress-nginx). ORDER MATTERS:
-  # the nginx base image must be built and pushed BEFORE the controller,
-  # since the controller uses it as BASE_IMAGE. Do not reorder.
-  # See docs/CHAINGUARD_FORKS.md for the catalog and bump procedure.
-  #
-  # KNOWN LIMITATION (to fix in the future): the build.git_source schema
-  # accepts a single `ref`, while `tag` can be a list. As a result we can
-  # build only one version of the fork per entry: supporting multiple
-  # versions today requires duplicating the entry (one per ref). When we
-  # need to publish more than one supported line of the fork in parallel,
-  # extend the schema so that `git_source` and `tag` (and BASE_IMAGE) can
-  # be paired across multiple versions in a single entry.
-
-  - name: nginx base image [Chainguard fork]
-    source: ingress-nginx-chainguard-nginx
-    multi-arch: true
-    build:
-      git_source:
-        repo: https://github.com/chainguard-forks/ingress-nginx.git
-        ref: controller-v1.15.5
-      context: images/nginx/rootfs
-      # No build-args needed: the inner Dockerfile uses a fixed FROM alpine:3.23.3
-    tag:
-      - "v2.2.9-chainguard"
-    destinations:
-      - registry.sighup.io/fury/ingress-nginx/nginx
-
-  - name: nginx ingress controller [Chainguard fork]
-    source: ingress-nginx-chainguard-controller
-    multi-arch: true
-    build:
-      git_source:
-        repo: https://github.com/chainguard-forks/ingress-nginx.git
-        ref: controller-v1.15.5
-      context: rootfs
-      args:
-        - name: BASE_IMAGE
-          value: "registry.sighup.io/fury/ingress-nginx/nginx:v2.2.9-chainguard"
-        - name: VERSION
-          value: "v1.15.5"
-    tag:
-      - "v1.15.5-chainguard"
-    destinations:
-      - registry.sighup.io/fury/ingress-nginx/controller

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -433,7 +433,31 @@ sync_build_based_image() {
     else
         context_path="$(dirname "${config_file}")/${build_context}"
     fi
-    
+
+    # Optional build.pre_build_commands: list of shell commands executed
+    # sequentially in dirname(context_path) AFTER the (optional) git_source
+    # clone and BEFORE the docker buildx build. Used for builds whose
+    # Dockerfile is not self-contained and requires code generation,
+    # cross-compilation, or other prep — e.g. the Chainguard ingress-nginx
+    # fork needs `make build ARCH=<x>` to produce Go binaries that the
+    # controller Dockerfile then COPYs into the final image.
+    local pre_build_count
+    pre_build_count=$(yq e ".images[${image_index}].build.pre_build_commands | length // 0" "${config_file}")
+    if [[ "${pre_build_count}" != "null" && "${pre_build_count}" -gt 0 ]]; then
+        local pre_build_cwd
+        pre_build_cwd=$(dirname "${context_path}")
+        for (( pb_index=0; pb_index<pre_build_count; pb_index++ )); do
+            local pb_cmd
+            pb_cmd=$(yq e ".images[${image_index}].build.pre_build_commands[${pb_index}]" "${config_file}")
+            if [[ "${dry_run}" == "true" ]]; then
+                tree_log info "├── " 2 "🏃 DRY RUN: Would run pre-build (cwd=${pre_build_cwd}): ${pb_cmd}"
+            else
+                tree_log info "├── " 2 "🔧 Running pre-build (cwd=${pre_build_cwd}): ${pb_cmd}"
+                ( cd "${pre_build_cwd}" && bash -c "${pb_cmd}" >&2 )
+            fi
+        done
+    fi
+
     if [[ "${dry_run}" == "true" ]]; then
         if [[ "${multi_arch_enabled}" == "true" ]]; then
             tree_log info "├── " 2 "🏃 DRY RUN: Would build multi-arch image to ${first_destination}:${tag}"

--- a/scripts/test-sync.sh
+++ b/scripts/test-sync.sh
@@ -173,6 +173,7 @@ test_dry_run_commands() {
         check_command_in_output "${output}" "docker buildx build" "Build-based sync command" || all_passed=false
         check_command_in_output "${output}" "docker://registry.sighup.io/fury/testing/" "Test registry destination" || all_passed=false
         check_command_in_output "${output}" "Would clone https://github.com/docker-library/hello-world.git" "git_source clone command" || all_passed=false
+        check_command_in_output "${output}" "Would run pre-build" "pre_build_commands dry-run output" || all_passed=false
         
         if [[ "${all_passed}" == "true" ]]; then
             log_test_pass "All expected commands found in dry-run output"


### PR DESCRIPTION
# Summary

Following #402 , the controller build was failing not finding the go built binaries, added a pre build command and moved che chainguard forks on it's own folder