### PR TITLE
feat: mirror haproxy ingress controller v3.2.8

### DIFF
--- a/modules/ingress/images.yml
+++ b/modules/ingress/images.yml
@@ -173,5 +173,6 @@ images:
     tag:
       - "3.1.14"
       - "3.2.4"
+      - "3.2.8"
     destinations:
       - registry.sighup.io/fury/haproxytech/kubernetes-ingress


### PR DESCRIPTION
# Summary

Mirror HAProxy ingress controller image v3.2.8 to the SIGHUP registry.