### PR TITLE
feat(monitoring): add new image versions 

### DIFF
--- a/modules/logging/images.yml
+++ b/modules/logging/images.yml
@@ -280,6 +280,7 @@ images:
     tag:
       - "1.6.23-alpine"
       - "1.6.31-alpine"
+      - "1.6.39-alpine"
     destinations:
       - registry.sighup.io/fury/memcached
 
@@ -288,5 +289,6 @@ images:
     tag:
       - "v0.14.2"
       - "v0.14.4"
+      - "v0.15.3"
     destinations:
       - registry.sighup.io/fury/prom/memcached-exporter

--- a/modules/monitoring/images.yml
+++ b/modules/monitoring/images.yml
@@ -51,6 +51,7 @@ images:
       - "v0.24.0"
       - "v0.25.0"
       - "v0.27.0"
+      - "v0.28.0"
     destinations:
       - registry.sighup.io/fury/prometheus/blackbox-exporter
 
@@ -131,6 +132,7 @@ images:
       - "v2.9.2"
       - "v2.13.0"
       - "v2.16.0"
+      - "v2.18.0"
     destinations:
       - registry.sighup.io/fury/kube-state-metrics/kube-state-metrics
 
@@ -160,6 +162,7 @@ images:
       - "v2.46.0"
       - "v2.54.1"
       - "v3.5.0"
+      - "v3.10.0"
     destinations:
       - registry.sighup.io/fury/prometheus
       - registry.sighup.io/fury/prometheus/prometheus
@@ -187,6 +190,7 @@ images:
       - "v0.67.1"
       - "v0.76.2"
       - "v0.85.0"
+      - "v0.89.0"
     destinations:
       - registry.sighup.io/fury/prometheus-operator/prometheus-operator
 
@@ -260,6 +264,7 @@ images:
       - "3.17.0"
       - "3.18.1"
       - "3.19.1"
+      - "4.1.0"
     destinations:
       - registry.sighup.io/fury/enix/x509-certificate-exporter
 
@@ -280,6 +285,7 @@ images:
       - "2.14.0"
       - "2.15.0"
       - "2.17.0"
+      - "3.0.4"
     destinations:
       - registry.sighup.io/fury/grafana/mimir
 
@@ -303,6 +309,7 @@ images:
       - "v0.14.2"
       - "v0.18.1"
       - "v0.19.1"
+      - "v0.21.0"
     destinations:
       - registry.sighup.io/fury/brancz/kube-rbac-proxy
 


### PR DESCRIPTION
feat(monitoring): add new image versions  for memcached, memcached-exporter, blackbox-exporter, kube-state-metrics, prometheus, prometheus-operator, x509-certificate-exporter, mimir and kube-rbac-proxy