### PR TITLE
Feat/calico 3.32.0

### DIFF
--- a/modules/networking/images.yml
+++ b/modules/networking/images.yml
@@ -13,6 +13,7 @@ images:
       - "v1.38.0"
       - "v1.38.6"
       - "v1.40.3"
+      - "v1.42.0"
     destinations:
       - registry.sighup.io/fury/tigera/operator
 
@@ -40,6 +41,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/kube-controllers
 
@@ -68,6 +70,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/cni
 
@@ -96,6 +99,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/pod2daemon-flexvol
 
@@ -124,6 +128,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/node
 
@@ -141,6 +146,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/apiserver
 
@@ -158,6 +164,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/typha
 
@@ -176,6 +183,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/csi
 
@@ -194,6 +202,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/node-driver-registrar
 
@@ -204,6 +213,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/dikastes
 
@@ -214,6 +224,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/goldmane
       
@@ -224,6 +235,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/whisker
 
@@ -234,6 +246,7 @@ images:
       - "v3.30.0"
       - "v3.30.3"
       - "v3.31.3"
+      - "v3.32.0"
     destinations:
       - registry.sighup.io/fury/calico/whisker-backend
 

--- a/modules/networking/images.yml
+++ b/modules/networking/images.yml
@@ -265,20 +265,6 @@ images:
     destinations:
       - registry.sighup.io/fury/google_containers/echoserver
 
-  - name: IP Masq [Fury Networking Module]
-    source: gcr.io/google-containers/ip-masq-agent-amd64
-    tag:
-      - "v2.5.0"
-    destinations:
-      - registry.sighup.io/fury/google-containers/ip-masq-agent-amd64
-
-  - name: IP Masq [Fury Networking Module]
-    source: k8s.gcr.io/networking/ip-masq-agent
-    tag:
-      - "v2.8.0"
-    destinations:
-      - registry.sighup.io/fury/networking/ip-masq-agent
-
   - name: Cilium
     source: quay.io/cilium/cilium
     multi-arch: true


### PR DESCRIPTION
- Add Calico 3.32.0 and Tigera Operator 1.42.0
- Remove deprecated IPMasq from networking module images sync