### PR TITLE
feat(aws): mirror images for k8s 1.35

### DIFF
--- a/modules/aws/images.yml
+++ b/modules/aws/images.yml
@@ -10,6 +10,7 @@ images:
       - "v1.25.0"
       - "v1.25.2"
       - "v1.25.3"
+      - "v1.25.6"
     destinations:
       - registry.sighup.io/fury/aws-ec2/aws-node-termination-handler
 
@@ -32,6 +33,7 @@ images:
       - "v1.32.0"
       - "v1.33.0"
       - "v1.34.0"
+      - "v1.35.0"
     destinations:
       - registry.sighup.io/fury/autoscaling/cluster-autoscaler
 
@@ -46,6 +48,7 @@ images:
       - "v2.12.0"
       - "v2.13.4"
       - "v2.16.0"
+      - "v3.4.0"
     destinations:
       - registry.sighup.io/fury/amazon/aws-alb-ingress-controller
 


### PR DESCRIPTION
Mirror the AWS images needed by module-aws v5.3.0 (Kubernetes 1.35 + component bumps):

- cluster-autoscaler `v1.35.0` (Kubernetes 1.35 support)
- aws-node-termination-handler `v1.25.6`
- aws-load-balancer-controller `v3.4.0`