### PR TITLE
fix(on-prem): change kubelet-csr-approver destination to fury/on-premises

### DIFF
--- a/modules/on-premises/custom/kubelet-csr-approver/Dockerfile
+++ b/modules/on-premises/custom/kubelet-csr-approver/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE=3.20
+ARG ALPINE=3.23.5
 FROM alpine:${ALPINE}
 
 RUN apk add --no-cache bash curl jq openssl kubectl sed

--- a/modules/on-premises/images.yml
+++ b/modules/on-premises/images.yml
@@ -212,4 +212,4 @@ images:
     tag:
       - "v1.0"
     destinations:
-      - registry.sighup.io/fury/kubelet-csr-approver
+      - registry.sighup.io/fury/on-premises/kubelet-csr-approver

--- a/modules/on-premises/images.yml
+++ b/modules/on-premises/images.yml
@@ -208,7 +208,7 @@ images:
       context: custom/kubelet-csr-approver
       args:
         - name: ALPINE
-          value: "3.20"
+          value: "3.23.5"
     tag:
       - "v1.0"
     destinations:


### PR DESCRIPTION
Moved from `destination registry.sighup.io/fury/kubelet-csr-approver` to `registry.sighup.io/fury/on-premises/kubelet-csr-approver`