### PR TITLE
feat(utilities): replace kubectl-jq with curl-jq v3.24.1 image

### DIFF
--- a/modules/extra/custom/curl-jq/Dockerfile
+++ b/modules/extra/custom/curl-jq/Dockerfile
@@ -1,0 +1,4 @@
+ARG ALPINE="3.24.1"
+FROM alpine:${ALPINE}
+
+RUN apk add --no-cache curl jq

--- a/modules/extra/images.yml
+++ b/modules/extra/images.yml
@@ -289,12 +289,18 @@ images:
     destinations:
       - registry.sighup.io/fury/sig-storage/nfs-subdir-external-provisioner
 
-  - name: Kubectl JQ # https://github.com/sighupio/generic-container-images/blob/master/kubectl-jq/Dockerfile
-    source: quay.io/sighup/kubectl-jq
+  - name: Alpine-based image with curl and jq
+    source: curl-jq
+    multi-arch: true
+    build:
+      context: custom/curl-jq
+      args:
+        - name: ALPINE
+          value: "3.24.1"
     tag:
-      - "1.29.3"
+      - "3.24.1"
     destinations:
-      - registry.sighup.io/fury/kubectl-jq
+      - registry.sighup.io/fury/curl-jq
 
   #- name: RabbitMQ (bitnami) ### DISABLED DUE TO BITNAMI BECOMING CLOSED SOURCE
   #  source: docker.io/bitnami/rabbitmq


### PR DESCRIPTION
feat(utilities): replace kubectl-jq with curl-jq v3.24.1 image

⚠️ Manual action: delete image tag `registry.sighup.io/fury/kubectl-jq:1.29.3`